### PR TITLE
fix(website): remove .mdx from page.url

### DIFF
--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -30,7 +30,7 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
       <div className="flex flex-row gap-2 items-center border-b pt-2 pb-6">
         <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
         <ViewOptions
-          markdownUrl={`${page.url}.mdx`}
+          markdownUrl={`${page.url}`}
           githubUrl={`https://github.com/swiftly-solution/website/blob/main/content/docs/${page.path}`}
         />
       </div>


### PR DESCRIPTION
Currently it sends the url with .mdx causing problems with the AIs (400 Bad Request)