### PR TITLE
refactor: Migrate Icon System and Enhance Homepage/Navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "fumadocs-mdx": "12.0.1",
     "fumadocs-ui": "15.8.0",
     "hast-util-to-jsx-runtime": "^2.3.6",
-    "lucide-react": "^0.544.0",
+    "react-icons": "^5.4.0",
     "next": "15.5.4",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,10 +1,36 @@
+"use client";
+
 import Link from 'next/link';
 import SwiftlyLogo from "./logo.png";
 import MenusPreview from "./menus_preview.png";
 import Image from 'next/image';
 import { CodeBlock } from '@/components/code-block';
+import { Download, FlaskConical, ShieldCheck } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 
 export default function HomePage() {
+  const [isDownloadOpen, setDownloadOpen] = useState(false);
+  const downloadRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (!downloadRef.current?.contains(event.target as Node)) {
+        setDownloadOpen(false);
+      }
+    };
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setDownloadOpen(false);
+    };
+
+    window.addEventListener('mousedown', handleClick);
+    window.addEventListener('keyup', handleKey);
+    return () => {
+      window.removeEventListener('mousedown', handleClick);
+      window.removeEventListener('keyup', handleKey);
+    };
+  }, []);
+
   return (
     <main className="flex flex-1 flex-col">
 
@@ -23,19 +49,58 @@ export default function HomePage() {
                 Build modern game server plugins with the full power of .NET and C#.
                 Hot reload, async/await, and native Source 2 integration.
               </p>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center md:justify-start pt-4">
+              <div className="flex flex-col sm:flex-row gap-3 justify-center md:justify-start pt-4">
                 <Link
                   href="/docs"
                   className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 rounded-md font-medium transition-colors text-center"
                 >
                   Get Started
                 </Link>
-                <Link
-                  href="/docs/api"
-                  className="border border-neutral-700 hover:border-neutral-600 hover:bg-neutral-900 px-8 py-3 rounded-md font-medium transition-colors text-center"
-                >
-                  API Reference
-                </Link>
+                <div className="relative" ref={downloadRef}>
+                  <button
+                    type="button"
+                    onClick={() => setDownloadOpen((v) => !v)}
+                    className="border border-neutral-700 hover:border-neutral-600 hover:bg-neutral-900 px-8 py-3 rounded-md font-medium transition-all text-center cursor-pointer select-none inline-flex items-center gap-2 shadow-sm hover:shadow"
+                    aria-expanded={isDownloadOpen}
+                    aria-haspopup="menu"
+                  >
+                    <Download className="h-4 w-4" aria-hidden="true" />
+                    Download
+                  </button>
+                  <div
+                    role="menu"
+                    className={`absolute z-10 mt-2 min-w-[220px] rounded-md border border-neutral-800 bg-neutral-950/95 shadow-xl backdrop-blur origin-top transition-all duration-150 ease-out ${
+                      isDownloadOpen
+                        ? 'opacity-100 scale-100 pointer-events-auto'
+                        : 'opacity-0 scale-95 pointer-events-none'
+                    }`}
+                  >
+                    <div className="px-4 py-2 text-xs uppercase tracking-[0.08em] text-neutral-500">Choose build</div>
+                    <a
+                      href="https://github.com/swiftly-solution/swiftlys2/releases/latest"
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-neutral-900"
+                      target="_blank"
+                      rel="noreferrer"
+                      role="menuitem"
+                      onClick={() => setDownloadOpen(false)}
+                    >
+                      <ShieldCheck className="h-4 w-4 text-green-400" aria-hidden="true" />
+                      Latest Stable
+                    </a>
+                    <a
+                      href="https://github.com/swiftly-solution/swiftlys2/releases"
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-neutral-900"
+                      target="_blank"
+                      rel="noreferrer"
+                      role="menuitem"
+                      onClick={() => setDownloadOpen(false)}
+                    >
+                      <FlaskConical className="h-4 w-4 text-yellow-400" aria-hidden="true" />
+                      Latest Beta
+                    </a>
+                    <div className="px-4 py-2 text-xs text-neutral-500 border-t border-neutral-800">Opens in GitHub Releases</div>
+                  </div>
+                </div>
               </div>
             </div>
             <div className="flex justify-center">

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -5,7 +5,7 @@ import SwiftlyLogo from "./logo.png";
 import MenusPreview from "./menus_preview.png";
 import Image from 'next/image';
 import { CodeBlock } from '@/components/code-block';
-import { Download, FlaskConical, ShieldCheck } from 'lucide-react';
+import { LuDownload, LuFlaskConical, LuShieldCheck } from 'react-icons/lu';
 import { useEffect, useRef, useState } from 'react';
 
 export default function HomePage() {
@@ -64,7 +64,7 @@ export default function HomePage() {
                     aria-expanded={isDownloadOpen}
                     aria-haspopup="menu"
                   >
-                    <Download className="h-4 w-4" aria-hidden="true" />
+                    <LuDownload className="h-4 w-4" aria-hidden="true" />
                     Download
                   </button>
                   <div
@@ -84,7 +84,7 @@ export default function HomePage() {
                       role="menuitem"
                       onClick={() => setDownloadOpen(false)}
                     >
-                      <ShieldCheck className="h-4 w-4 text-green-400" aria-hidden="true" />
+                      <LuShieldCheck className="h-4 w-4 text-green-400" aria-hidden="true" />
                       Latest Stable
                     </a>
                     <a
@@ -95,7 +95,7 @@ export default function HomePage() {
                       role="menuitem"
                       onClick={() => setDownloadOpen(false)}
                     >
-                      <FlaskConical className="h-4 w-4 text-yellow-400" aria-hidden="true" />
+                      <LuFlaskConical className="h-4 w-4 text-yellow-400" aria-hidden="true" />
                       Latest Beta
                     </a>
                     <div className="px-4 py-2 text-xs text-neutral-500 border-t border-neutral-800">Opens in GitHub Releases</div>

--- a/src/components/page-actions.tsx
+++ b/src/components/page-actions.tsx
@@ -1,12 +1,12 @@
 'use client';
 import { useMemo, useState } from 'react';
 import {
-  Check,
-  ChevronDown,
-  Copy,
-  ExternalLinkIcon,
-  MessageCircleIcon,
-} from 'lucide-react';
+  LuCheck,
+  LuChevronDown,
+  LuCopy,
+  LuExternalLink,
+  LuMessageCircle,
+} from 'react-icons/lu';
 import { cn } from '../lib/cn';
 import { useCopyButton } from 'fumadocs-ui/utils/use-copy-button';
 import { buttonVariants } from './ui/button';
@@ -62,7 +62,7 @@ export function LLMCopyButton({
       )}
       onClick={onClick}
     >
-      {checked ? <Check /> : <Copy />}
+      {checked ? <LuCheck /> : <LuCopy />}
       Copy Markdown
     </button>
   );
@@ -208,7 +208,7 @@ export function ViewOptions({
         href: `https://t3.chat/new?${new URLSearchParams({
           q,
         })}`,
-        icon: <MessageCircleIcon />,
+        icon: <LuMessageCircle />,
       },
     ];
   }, [githubUrl, markdownUrl]);
@@ -225,7 +225,7 @@ export function ViewOptions({
         )}
       >
         Open
-        <ChevronDown className="size-3.5 text-fd-muted-foreground" />
+        <LuChevronDown className="size-3.5 text-fd-muted-foreground" />
       </PopoverTrigger>
       <PopoverContent className="flex flex-col overflow-auto">
         {items.map((item) => (
@@ -238,7 +238,7 @@ export function ViewOptions({
           >
             {item.icon}
             {item.title}
-            <ExternalLinkIcon className="text-fd-muted-foreground size-3.5 ms-auto" />
+            <LuExternalLink className="text-fd-muted-foreground size-3.5 ms-auto" />
           </a>
         ))}
       </PopoverContent>

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Loader2, RefreshCw, SearchIcon, Send, X } from 'lucide-react';
+import { LuLoader2, LuRefreshCw, LuSearch, LuSend, LuX } from 'react-icons/lu';
 import { cn } from '../lib/cn';
 import { buttonVariants } from './ui/button';
 import Link from 'fumadocs-core/link';
@@ -51,7 +51,7 @@ function SearchAIActions() {
           )}
           onClick={() => regenerate()}
         >
-          <RefreshCw className="size-4" />
+          <LuRefreshCw className="size-4" />
           Retry
         </button>
       )}
@@ -119,7 +119,7 @@ function SearchAIInput(props: ComponentProps<'form'>) {
           )}
           onClick={stop}
         >
-          <Loader2 className="size-4 animate-spin text-fd-muted-foreground" />
+          <LuLoader2 className="size-4 animate-spin text-fd-muted-foreground" />
           Abort Answer
         </button>
       ) : (
@@ -134,7 +134,7 @@ function SearchAIInput(props: ComponentProps<'form'>) {
           )}
           disabled={input.length === 0}
         >
-          <Send className="size-4" />
+          <LuSend className="size-4" />
         </button>
       )}
     </form>
@@ -320,7 +320,7 @@ export function AISearchTrigger() {
                 )}
                 onClick={() => setOpen(false)}
               >
-                <X />
+                <LuX />
               </button>
             </div>
             <List
@@ -361,7 +361,7 @@ export function AISearchTrigger() {
               )}
               onClick={() => setOpen(true)}
             >
-              <SearchIcon className="absolute top-1/2 -translate-y-1/2 size-4.5" />
+              <LuSearch className="absolute top-1/2 -translate-y-1/2 size-4.5" />
               Ask AI
             </button>
           </Presence>

--- a/src/lib/layout.shared.tsx
+++ b/src/lib/layout.shared.tsx
@@ -1,4 +1,5 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
+import { BsGithub, BsDiscord } from 'react-icons/bs';
 
 /**
  * Shared layout configurations
@@ -18,15 +19,26 @@ export function baseOptions(): BaseLayoutProps {
     },
     links: [
       {
-        text: "Discord",
-        url: "https://swiftlys2.net/discord",
-        external: true,
+        text: "Documentation",
+        url: "/docs",
+        external: false,
       },
       {
+        type: "icon",
+        label: "GitHub",
+        icon: <BsGithub />,
         text: "GitHub",
         url: "https://github.com/swiftly-solution",
         external: true,
-      }
+      },
+      {
+        type: "icon",
+        label: "Discord",
+        icon: <BsDiscord />,
+        text: "Discord",
+        url: "/discord", // (swiftlys2.net/discord)
+        external: true,
+      },
     ],
   };
 }


### PR DESCRIPTION
This pull request refactors the icon usage throughout the codebase by replacing the `lucide-react` icon library with `react-icons`, and updates UI components to use the new icons. It also introduces a new "Download" dropdown button on the homepage, and improves the layout navigation links to include icon-based entries for GitHub and Discord.

**Icon Library Migration and Refactoring:**

* Replaces `lucide-react` with `react-icons` in `package.json`, updating all icon imports and usages in `src/components/page-actions.tsx` and `src/components/search.tsx` to use the new icon set. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L24-R24) [[2]](diffhunk://#diff-0686350e3bef23ad7b5da59a8639e18359c2f22a75a2ba46621ba0734414fc28L4-R9) [[3]](diffhunk://#diff-0686350e3bef23ad7b5da59a8639e18359c2f22a75a2ba46621ba0734414fc28L65-R65) [[4]](diffhunk://#diff-0686350e3bef23ad7b5da59a8639e18359c2f22a75a2ba46621ba0734414fc28L211-R211) [[5]](diffhunk://#diff-0686350e3bef23ad7b5da59a8639e18359c2f22a75a2ba46621ba0734414fc28L228-R228) [[6]](diffhunk://#diff-0686350e3bef23ad7b5da59a8639e18359c2f22a75a2ba46621ba0734414fc28L241-R241) [[7]](diffhunk://#diff-d13ac0416f1bec93e4eaf455a1a38d0a160412858c9150e39e98649069dd07a6L13-R13) [[8]](diffhunk://#diff-d13ac0416f1bec93e4eaf455a1a38d0a160412858c9150e39e98649069dd07a6L54-R54) [[9]](diffhunk://#diff-d13ac0416f1bec93e4eaf455a1a38d0a160412858c9150e39e98649069dd07a6L122-R122) [[10]](diffhunk://#diff-d13ac0416f1bec93e4eaf455a1a38d0a160412858c9150e39e98649069dd07a6L137-R137) [[11]](diffhunk://#diff-d13ac0416f1bec93e4eaf455a1a38d0a160412858c9150e39e98649069dd07a6L323-R323) [[12]](diffhunk://#diff-d13ac0416f1bec93e4eaf455a1a38d0a160412858c9150e39e98649069dd07a6L364-R364)

**Homepage UI Enhancement:**

* Adds a "Download" dropdown button to the homepage (`src/app/(home)/page.tsx`) with options for "Latest Stable" and "Latest Beta" releases, including improved accessibility and outside-click/escape handling. [[1]](diffhunk://#diff-083b47e335af1cbf2a7f861ccfce83cb51b0c1ca359cc4d7b68490ea9ffee7a6R1-R33) [[2]](diffhunk://#diff-083b47e335af1cbf2a7f861ccfce83cb51b0c1ca359cc4d7b68490ea9ffee7a6L26-R103)

**Navigation and Layout Improvements:**

* Updates shared layout navigation links in `src/lib/layout.shared.tsx` to include icon-based links for GitHub and Discord, and changes the documentation link to a local route. [[1]](diffhunk://#diff-6ca7fe03d3aaca22770db1a20a47e2b679cc65262b3907b7184e8b5a6657bc76R2) [[2]](diffhunk://#diff-6ca7fe03d3aaca22770db1a20a47e2b679cc65262b3907b7184e8b5a6657bc76L21-R41)